### PR TITLE
Add unit test for position/index roundtrip

### DIFF
--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -221,3 +221,32 @@ impl TableBuilder {
         index
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shakmaty::fen::Fen;
+
+    #[test]
+    fn position_index_roundtrip() {
+        let tb = TableBuilder {
+            material: vec![
+                Piece::from_char('K').unwrap(),
+                Piece::from_char('Q').unwrap(),
+                Piece::from_char('k').unwrap(),
+            ],
+            positions: Vec::new(),
+        };
+
+        let position = "7k/8/8/8/8/8/8/KQ6 w - - 0 1"
+            .parse::<Fen>()
+            .unwrap()
+            .into_position(CastlingMode::Standard)
+            .unwrap();
+
+        let index = tb.position_to_index(&position);
+        let reconstructed = tb.index_to_position(index).expect("valid position");
+
+        assert_eq!(tb.position_to_index(&reconstructed), index);
+    }
+}


### PR DESCRIPTION
## Summary
- add a test ensuring position_to_index and index_to_position roundtrip correctly
- build the test position from a FEN string for clarity

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e8b55f7a883208943ff70cb573dbf