### PR TITLE
Introduce MaterialKey for table builder

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,19 @@
+mod material_key;
 mod score;
 mod table_builder;
 
+use material_key::MaterialKey;
 use shakmaty::Piece;
 use table_builder::TableBuilder;
 
 fn main() {
-    let mut table_builder = TableBuilder::new(vec![
+    let material = MaterialKey::new(vec![
         Piece::from_char('K').unwrap(),
         Piece::from_char('Q').unwrap(),
         Piece::from_char('k').unwrap(),
     ]);
+
+    let mut table_builder = TableBuilder::new(material);
 
     table_builder.solve();
 }

--- a/src/material_key.rs
+++ b/src/material_key.rs
@@ -1,0 +1,61 @@
+use std::fmt;
+use std::ops::Deref;
+
+use shakmaty::{Color, Piece, Role};
+
+/// Represents a material configuration, e.g. `KQvK`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaterialKey {
+    pieces: Vec<Piece>,
+}
+
+impl MaterialKey {
+    /// Create a new material key from a list of pieces.
+    pub fn new(pieces: Vec<Piece>) -> Self {
+        Self { pieces }
+    }
+}
+
+impl Deref for MaterialKey {
+    type Target = [Piece];
+
+    fn deref(&self) -> &Self::Target {
+        &self.pieces
+    }
+}
+
+impl fmt::Display for MaterialKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut white: Vec<char> = Vec::new();
+        let mut black: Vec<char> = Vec::new();
+
+        for piece in &self.pieces {
+            let ch = match piece.role {
+                Role::King => 'K',
+                Role::Queen => 'Q',
+                Role::Rook => 'R',
+                Role::Bishop => 'B',
+                Role::Knight => 'N',
+                Role::Pawn => 'P',
+            };
+
+            if piece.color == Color::White {
+                white.push(ch);
+            } else {
+                black.push(ch);
+            }
+        }
+
+        for c in white {
+            write!(f, "{}", c)?;
+        }
+
+        write!(f, "v")?;
+
+        for c in black {
+            write!(f, "{}", c)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -1,13 +1,14 @@
+use crate::material_key::MaterialKey;
 use crate::score::DtzScoreRange;
 use shakmaty::{CastlingMode, Chess, FromSetup, Piece, Position, Setup, Square};
 
 pub struct TableBuilder {
-    material: Vec<Piece>,
+    material: MaterialKey,
     positions: Vec<DtzScoreRange>,
 }
 
 impl TableBuilder {
-    pub fn new(material: Vec<Piece>) -> Self {
+    pub fn new(material: MaterialKey) -> Self {
         let positions = Self::total_positions(&material);
 
         Self {
@@ -58,7 +59,7 @@ impl TableBuilder {
         }
     }
 
-    fn total_positions(material: &Vec<Piece>) -> usize {
+    fn total_positions(material: &MaterialKey) -> usize {
         64usize.pow(material.len() as u32)
     }
 
@@ -107,11 +108,11 @@ mod tests {
     #[test]
     fn position_index_roundtrip() {
         let tb = TableBuilder {
-            material: vec![
+            material: MaterialKey::new(vec![
                 Piece::from_char('K').unwrap(),
                 Piece::from_char('Q').unwrap(),
                 Piece::from_char('k').unwrap(),
-            ],
+            ]),
             positions: Vec::new(),
         };
 


### PR DESCRIPTION
## Summary
- add MaterialKey struct to encapsulate piece lists like `KQvK`
- swap TableBuilder to use MaterialKey instead of raw Vec<Piece>
- update main and tests for new API
- derive Debug, PartialEq, and Eq for MaterialKey to enable comparisons and easier debugging

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e93d413588320935c944ede53381c