### PR TITLE
Add random roundtrip tests for MaterialKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,11 +30,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "heisenbase"
 version = "0.1.0"
 dependencies = [
+ "rand",
  "shakmaty",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "nohash-hasher"
@@ -49,6 +73,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -67,6 +100,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -118,3 +181,29 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 shakmaty = "0.29.0"
+
+[dev-dependencies]
+rand = "0.8"

--- a/src/material_key.rs
+++ b/src/material_key.rs
@@ -179,6 +179,7 @@ impl fmt::Display for MaterialKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
     use shakmaty::Piece;
 
     #[test]
@@ -202,5 +203,48 @@ mod tests {
     #[test]
     fn rejects_missing_separator() {
         assert!(MaterialKey::from_string("KQK").is_none());
+    }
+
+    fn roundtrip_random_indices(mk: MaterialKey, seed: u64) {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut successes = 0;
+        while successes < 10 {
+            let index = rng.gen_range(0..mk.total_positions());
+            if let Some(pos) = mk.index_to_position(index) {
+                let roundtrip = mk.position_to_index(&pos);
+                assert_eq!(index, roundtrip);
+                successes += 1;
+            }
+        }
+    }
+
+    #[test]
+    fn roundtrip_kvk() {
+        let mk = MaterialKey::from_string("KvK").unwrap();
+        roundtrip_random_indices(mk, 0);
+    }
+
+    #[test]
+    fn roundtrip_kqvk() {
+        let mk = MaterialKey::from_string("KQvK").unwrap();
+        roundtrip_random_indices(mk, 1);
+    }
+
+    #[test]
+    fn roundtrip_krvkb() {
+        let mk = MaterialKey::from_string("KRvKB").unwrap();
+        roundtrip_random_indices(mk, 2);
+    }
+
+    #[test]
+    fn roundtrip_kqvkr() {
+        let mk = MaterialKey::from_string("KQvKR").unwrap();
+        roundtrip_random_indices(mk, 3);
+    }
+
+    #[test]
+    fn roundtrip_kbnvkq() {
+        let mk = MaterialKey::from_string("KBNvKQ").unwrap();
+        roundtrip_random_indices(mk, 4);
     }
 }


### PR DESCRIPTION
## Summary
- add `rand` as a dev dependency
- test MaterialKey index roundtrips using random positions for several piece sets

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688e9d873bd88320b7b86169bb015d91