### PR TITLE
Store piece counts in MaterialKey

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,15 +3,10 @@ mod score;
 mod table_builder;
 
 use material_key::MaterialKey;
-use shakmaty::Piece;
 use table_builder::TableBuilder;
 
 fn main() {
-    let material = MaterialKey::new(vec![
-        Piece::from_char('K').unwrap(),
-        Piece::from_char('Q').unwrap(),
-        Piece::from_char('k').unwrap(),
-    ]);
+    let material = MaterialKey::from_string("KQvK").unwrap();
 
     let mut table_builder = TableBuilder::new(material);
 

--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -63,16 +63,12 @@ impl TableBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use shakmaty::{CastlingMode, Piece, fen::Fen};
+    use shakmaty::{CastlingMode, fen::Fen};
 
     #[test]
     fn position_index_roundtrip() {
         let tb = TableBuilder {
-            material: MaterialKey::new(vec![
-                Piece::from_char('K').unwrap(),
-                Piece::from_char('Q').unwrap(),
-                Piece::from_char('k').unwrap(),
-            ]),
+            material: MaterialKey::from_string("KQvK").unwrap(),
             positions: Vec::new(),
         };
 


### PR DESCRIPTION
## Summary
- Track piece counts by color/role instead of a raw vector
- Build MaterialKey from counts and output using these tallies
- Expand counts into pieces for indexing and position mapping
- Remove `MaterialKey::new` and construct keys from strings

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688ea155b9148320bc6f17f49e4e4ec6