### PR TITLE
Handle duplicate pieces in material key

### DIFF
--- a/src/material_key.rs
+++ b/src/material_key.rs
@@ -6,10 +6,11 @@ use shakmaty::{CastlingMode, Chess, Color, FromSetup, Piece, Position, Role, Set
 /// bidirectional mapping between permutations of those pieces and compact
 /// indices.
 ///
-/// The mapping only covers legal permutations where every piece occupies a
-/// unique square. Illegal arrangements, such as overlapping pieces or
-/// duplicate-piece ambiguity, are considered invalid and are never assigned an
-/// index.
+/// The mapping only covers legal placements where every piece occupies a
+/// unique square. Identical pieces are treated as indistinguishable, so the
+/// mapping enumerates combinations of their placements without ambiguity. Any
+/// arrangement with overlapping pieces is considered invalid and is never
+/// assigned an index.
 const ROLES: [Role; 6] = [
     Role::King,
     Role::Queen,
@@ -99,10 +100,17 @@ impl MaterialKey {
     /// Total number of mappable positions for this material configuration.
     ///
     /// Each index corresponds to a unique permutation where all pieces appear
-    /// on distinct squares. Since squares cannot be reused, the total count is
-    /// `64 * 63 * 62 * ...` for as many pieces as are in the key.
+    /// on distinct squares. Identical pieces are treated as indistinguishable,
+    /// so their placements are counted combinatorially.
     pub fn total_positions(&self) -> usize {
-        (0..self.piece_count()).fold(1, |acc, i| acc * (64 - i))
+        let mut remaining = 64usize;
+        let mut total = 1usize;
+        for (_, count) in self.piece_groups() {
+            let c = n_choose_k(remaining, count as usize);
+            total *= c;
+            remaining -= count as usize;
+        }
+        total
     }
 
     /// Convert an index into a [`Chess`] position.
@@ -118,13 +126,18 @@ impl MaterialKey {
         let mut setup = Setup::empty();
         let mut squares: Vec<Square> = (0..64).map(|i| Square::new(i as u32)).collect();
 
-        let pieces = self.pieces();
-        for piece in pieces {
-            let base = squares.len();
-            let idx = pos_index % base;
+        for (piece, count) in self.piece_groups() {
+            let base = n_choose_k(squares.len(), count as usize);
+            let group_index = pos_index % base;
             pos_index /= base;
-            let square = squares.remove(idx);
-            setup.board.set_piece_at(square, piece);
+            let indices = unrank_combination(squares.len(), count as usize, group_index);
+            let chosen: Vec<Square> = indices.iter().map(|&i| squares[i]).collect();
+            for idx in indices.iter().rev() {
+                squares.remove(*idx);
+            }
+            for square in chosen {
+                setup.board.set_piece_at(square, piece);
+            }
         }
 
         Chess::from_setup(setup, CastlingMode::Standard).ok()
@@ -141,16 +154,28 @@ impl MaterialKey {
         let mut multiplier = 1usize;
         let mut squares: Vec<Square> = (0..64).map(|i| Square::new(i as u32)).collect();
 
-        let pieces = self.pieces();
-        for piece in pieces {
-            let base = squares.len();
-            let square = position.board().by_piece(piece).first().unwrap();
-            let idx = squares
-                .iter()
-                .position(|&s| s == square)
-                .expect("piece square must exist");
-            index += idx * multiplier;
-            squares.remove(idx);
+        for (piece, count) in self.piece_groups() {
+            let base = n_choose_k(squares.len(), count as usize);
+
+            let mut piece_indices: Vec<usize> = {
+                let bb = position.board().by_piece(piece);
+                let mut v = Vec::with_capacity(count as usize);
+                for sq in bb {
+                    let idx = squares
+                        .iter()
+                        .position(|&s| s == sq)
+                        .expect("piece square must exist");
+                    v.push(idx);
+                }
+                v
+            };
+            piece_indices.sort();
+            assert_eq!(piece_indices.len(), count as usize);
+            let group_index = rank_combination(squares.len(), piece_indices.as_slice());
+            index += group_index * multiplier;
+            for idx in piece_indices.iter().rev() {
+                squares.remove(*idx);
+            }
             multiplier *= base;
         }
 
@@ -184,27 +209,63 @@ impl fmt::Display for MaterialKey {
 }
 
 impl MaterialKey {
-    /// Number of pieces in this key.
-    fn piece_count(&self) -> usize {
-        self.counts
-            .iter()
-            .map(|c| c.iter().map(|&n| n as usize).sum::<usize>())
-            .sum()
-    }
-
-    /// Expand the piece counts into a vector of pieces in a canonical order.
-    fn pieces(&self) -> Vec<Piece> {
-        let mut pieces = Vec::with_capacity(self.piece_count());
+    /// Group identical pieces with their multiplicity.
+    fn piece_groups(&self) -> Vec<(Piece, u8)> {
+        let mut groups = Vec::new();
         for (color_idx, &color) in [Color::White, Color::Black].iter().enumerate() {
             for &role in &ROLES {
                 let count = self.counts[color_idx][role_index(role)];
-                for _ in 0..count {
-                    pieces.push(Piece { role, color });
+                if count > 0 {
+                    groups.push((Piece { role, color }, count));
                 }
             }
         }
-        pieces
+        groups
     }
+}
+
+fn n_choose_k(n: usize, k: usize) -> usize {
+    if k > n {
+        return 0;
+    }
+    let k = k.min(n - k);
+    let mut result: usize = 1;
+    for i in 1..=k {
+        result = result * (n - (k - i)) / i;
+    }
+    result
+}
+
+fn unrank_combination(n: usize, k: usize, mut rank: usize) -> Vec<usize> {
+    let mut combo = Vec::with_capacity(k);
+    let mut x = 0usize;
+    for i in 0..k {
+        let mut c = x;
+        loop {
+            let count = n_choose_k(n - c - 1, k - i - 1);
+            if count <= rank {
+                rank -= count;
+                c += 1;
+            } else {
+                combo.push(c);
+                x = c + 1;
+                break;
+            }
+        }
+    }
+    combo
+}
+
+fn rank_combination(n: usize, indices: &[usize]) -> usize {
+    let k = indices.len();
+    let mut rank = 0usize;
+    for (i, &c) in indices.iter().enumerate() {
+        let start = if i == 0 { 0 } else { indices[i - 1] + 1 };
+        for j in start..c {
+            rank += n_choose_k(n - j - 1, k - i - 1);
+        }
+    }
+    rank
 }
 
 #[cfg(test)]
@@ -232,6 +293,12 @@ mod tests {
     fn total_positions_without_overlap() {
         let mk = MaterialKey::from_string("KQvK").unwrap();
         assert_eq!(mk.total_positions(), 64 * 63 * 62);
+    }
+
+    #[test]
+    fn total_positions_with_duplicates() {
+        let mk = MaterialKey::from_string("KNNvK").unwrap();
+        assert_eq!(mk.total_positions(), 64 * (63 * 62 / 2) * 61);
     }
 
     fn roundtrip_random_indices(mk: MaterialKey, seed: u64) {
@@ -275,5 +342,11 @@ mod tests {
     fn roundtrip_kbnvkq() {
         let mk = MaterialKey::from_string("KBNvKQ").unwrap();
         roundtrip_random_indices(mk, 4);
+    }
+
+    #[test]
+    fn roundtrip_knnvk() {
+        let mk = MaterialKey::from_string("KNNvK").unwrap();
+        roundtrip_random_indices(mk, 5);
     }
 }


### PR DESCRIPTION
## Summary
- treat identical pieces combinatorially to avoid duplicate indices
- add roundtrip tests for duplicate pieces

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688ea51c97dc83208e2b2a30cb0e1946