### PR TITLE
Add WDL table conversion and score range enum

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod material_key;
 mod score;
 mod table_builder;
+mod wdl_score_range;
+mod wdl_table;
 
 use clap::{Parser, Subcommand};
 use material_key::MaterialKey;

--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -3,8 +3,8 @@ use crate::score::DtzScoreRange;
 use shakmaty::Position;
 
 pub struct TableBuilder {
-    material: MaterialKey,
-    positions: Vec<DtzScoreRange>,
+    pub(crate) material: MaterialKey,
+    pub(crate) positions: Vec<DtzScoreRange>,
 }
 
 impl TableBuilder {

--- a/src/wdl_score_range.rs
+++ b/src/wdl_score_range.rs
@@ -1,0 +1,36 @@
+use crate::score::{DtzScore, DtzScoreRange};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WdlScoreRange {
+    /// Position that can be a win, draw or loss
+    Unknown,
+    WinOrDraw,
+    DrawOrLoss,
+    Win,
+    Draw,
+    Loss,
+    /// This won't be used right now because the TableBuilder doesn't mark illegal positions
+    IllegalPosition,
+}
+
+impl From<DtzScoreRange> for WdlScoreRange {
+    fn from(score: DtzScoreRange) -> Self {
+        use WdlScoreRange::*;
+
+        let zero = DtzScore::draw();
+
+        if score.min > zero {
+            Win
+        } else if score.max < zero {
+            Loss
+        } else if score.min == zero && score.max == zero {
+            Draw
+        } else if score.min >= zero && score.max > zero {
+            WinOrDraw
+        } else if score.min < zero && score.max == zero {
+            DrawOrLoss
+        } else {
+            Unknown
+        }
+    }
+}

--- a/src/wdl_table.rs
+++ b/src/wdl_table.rs
@@ -1,0 +1,19 @@
+use crate::material_key::MaterialKey;
+use crate::table_builder::TableBuilder;
+use crate::wdl_score_range::WdlScoreRange;
+
+pub struct WdlTable {
+    pub material: MaterialKey,
+    pub positions: Vec<WdlScoreRange>,
+}
+
+impl From<TableBuilder> for WdlTable {
+    fn from(tb: TableBuilder) -> Self {
+        let positions = tb.positions.into_iter().map(WdlScoreRange::from).collect();
+
+        Self {
+            material: tb.material,
+            positions,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define `WdlScoreRange` to categorize win/draw/loss outcomes
- add `WdlTable` that converts a `TableBuilder` into WDL results
- expose `TableBuilder` fields for internal conversion

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688eb86bc4ec832098d308a30861125a