### PR TITLE
Track updates in table builder

### DIFF
--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -18,45 +18,56 @@ impl TableBuilder {
     }
 
     pub fn solve(&mut self) {
-        for i in 0..100 {
-            println!("Step {}", i);
-            self.step();
+        const MAX_STEPS: usize = 101;
+
+        for step in 0..MAX_STEPS {
+            let updates = self.step();
+            println!("Step {}: {} updates", step, updates);
+            if updates == 0 {
+                break;
+            }
+            if step == MAX_STEPS - 1 {
+                panic!("table build exceeded {} steps", MAX_STEPS);
+            }
         }
     }
 
     /// Perform one iteration of the table builder.
     ///
-    /// This performs one bellman update on every position in the table.
-    fn step(&mut self) {
+    /// This performs one bellman update on every position in the table and returns the number of
+    /// positions that changed.
+    fn step(&mut self) -> usize {
+        let mut updates = 0;
         for pos_index in 0..self.positions.len() {
+            let old = self.positions[pos_index];
             let position = self.material.index_to_position(pos_index);
 
             // If the position is invalid, skip it.
             if let Some(position) = position {
-                if position.is_checkmate() {
-                    self.positions[pos_index] = DtzScoreRange::checkmate();
-                    continue;
+                let new_score = if position.is_checkmate() {
+                    DtzScoreRange::checkmate()
+                } else if position.is_stalemate() || position.is_insufficient_material() {
+                    DtzScoreRange::draw()
+                } else {
+                    position
+                        .legal_moves()
+                        .into_iter()
+                        .map(|chess_move| {
+                            let mut child_position = position.clone();
+                            child_position.play_unchecked(chess_move);
+                            let child_index = self.material.position_to_index(&child_position);
+                            self.positions[child_index]
+                        })
+                        .fold(self.positions[pos_index], |a, b| a.negamax(&b))
+                };
+
+                if new_score != old {
+                    self.positions[pos_index] = new_score;
+                    updates += 1;
                 }
-
-                if position.is_stalemate() || position.is_insufficient_material() {
-                    self.positions[pos_index] = DtzScoreRange::draw();
-                    continue;
-                }
-
-                let score = position
-                    .legal_moves()
-                    .into_iter()
-                    .map(|chess_move| {
-                        let mut child_position = position.clone();
-                        child_position.play_unchecked(chess_move);
-                        let child_index = self.material.position_to_index(&child_position);
-                        self.positions[child_index]
-                    })
-                    .fold(self.positions[pos_index], |a, b| a.negamax(&b));
-
-                self.positions[pos_index] = score;
             }
         }
+        updates
     }
 }
 


### PR DESCRIPTION
## Summary
- Count updates during each table-building step and report them
- Halt solving once a step performs zero updates
- Limit solving to 101 steps and panic if the last step still produces updates

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688ec6bb75348320a93295750d74a67b