### PR TITLE
Add table generation output and file format

### DIFF
--- a/documentation/file_format.md
+++ b/documentation/file_format.md
@@ -1,0 +1,70 @@
+# Heisenbase WDL Table File Format
+
+This document describes the on‑disk format used for tables produced by the
+`generate` command.  A file contains a single compressed WDL table.  All
+multi‑byte integers are encoded in **little endian** byte order.
+
+## Overview
+
+| Offset | Size | Description |
+| ------ | ---- | ----------- |
+| 0      | 4    | Magic bytes `HBWD` identifying a WDL table |
+| 4      | 1    | Format version.  Currently `1` |
+| 5      | 1    | Length *N* of the material key string |
+| 6      | N    | ASCII material key (e.g. `KQvK`) |
+| 6+N    | 8    | Original table length (number of positions) |
+| 14+N   | 2    | Number of base symbols used for encoding |
+| 16+N   | 2    | Number *P* of substitution pairs |
+| …      | 4×P  | Each pair as two `u16` values `(a, b)` |
+| …      | 2    | Length *L* of the `code_lens` array |
+| …      | L    | Huffman code lengths (one `u8` per symbol) |
+| …      | 8    | Number of valid bits in the bitstream |
+| …      | 4    | Length *B* of the bitstream in bytes |
+| …      | B    | Huffman encoded data |
+
+The exact size of sections after the header depends on the table and the
+compression results.  The sections appear consecutively without padding.
+
+### Material Key
+
+The material key identifies which pieces are present in the table.  It is
+stored as a compact ASCII string such as `KQvK` where `v` separates the
+white and black pieces.  Its length is limited to 255 bytes.
+
+### Symbol Pairs
+
+Pair substitution replaces frequent adjacent value pairs with new symbols.
+`P` indicates how many new symbols were created.  For each new symbol the
+file contains the original pair `(a, b)` represented as two `u16` values.
+Symbols are numbered sequentially starting at `base_symbols`.
+
+### Code Lengths and Bitstream
+
+The `code_lens` array specifies the Huffman code length for each symbol.
+The encoded table is stored as a bitstream preceded by its exact bit
+length.  The bitstream is padded to whole bytes.
+
+## Versioning
+
+The version byte allows future changes.  Readers should verify the value
+before interpreting the rest of the file.  Files produced by the current
+implementation use version `1`.
+
+## Example
+
+The following pseudo‑code illustrates how a file can be read:
+
+```text
+read magic, version
+assert magic == "HBWD" && version == 1
+read material_key_length
+read material_key_string
+read orig_len
+read base_symbols
+read pair_count and pair entries
+read code_len_count and code_lens
+read bit_len and bitstream
+```
+
+The `read_wdl_file` function in the codebase follows this specification.
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod compression;
 pub mod material_key;
 pub mod score;
 pub mod table_builder;
+pub mod wdl_file;
 pub mod wdl_score_range;
 pub mod wdl_table;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 use clap::{Parser, Subcommand};
+use heisenbase::compression::compress_wdl;
 use heisenbase::material_key::MaterialKey;
 use heisenbase::table_builder::TableBuilder;
+use heisenbase::wdl_file::write_wdl_file;
+use heisenbase::wdl_table::WdlTable;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -26,6 +29,12 @@ fn main() {
             let material = MaterialKey::from_string(&material_key).expect("invalid material key");
             let mut table_builder = TableBuilder::new(material);
             table_builder.solve();
+            let wdl_table: WdlTable = table_builder.into();
+            let compressed = compress_wdl(&wdl_table.positions);
+            let filename = format!("{}.hbt", wdl_table.material);
+            write_wdl_file(&filename, &wdl_table.material, &compressed)
+                .expect("failed to write table file");
+            println!("Wrote table to {}", filename);
         }
     }
 }

--- a/src/wdl_file.rs
+++ b/src/wdl_file.rs
@@ -1,0 +1,136 @@
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::Path;
+
+use crate::compression::CompressedWdl;
+use crate::material_key::MaterialKey;
+
+const MAGIC: &[u8; 4] = b"HBWD";
+const VERSION: u8 = 1;
+
+/// Write a compressed WDL table to a file.
+pub fn write_wdl_file<P: AsRef<Path>>(
+    path: P,
+    material: &MaterialKey,
+    data: &CompressedWdl,
+) -> io::Result<()> {
+    let mut file = File::create(path)?;
+
+    // Header
+    file.write_all(MAGIC)?;
+    file.write_all(&[VERSION])?;
+
+    // Material key
+    let mk_string = material.to_string();
+    let mk_len = mk_string.len();
+    if mk_len > u8::MAX as usize {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "material key too long",
+        ));
+    }
+    file.write_all(&[mk_len as u8])?;
+    file.write_all(mk_string.as_bytes())?;
+
+    // Table metadata
+    file.write_all(&(data.orig_len as u64).to_le_bytes())?;
+    file.write_all(&data.base_symbols.to_le_bytes())?;
+
+    // Symbol pairs
+    file.write_all(&(data.sym_pairs.len() as u16).to_le_bytes())?;
+    for &(a, b) in &data.sym_pairs {
+        file.write_all(&a.to_le_bytes())?;
+        file.write_all(&b.to_le_bytes())?;
+    }
+
+    // Code lengths
+    file.write_all(&(data.code_lens.len() as u16).to_le_bytes())?;
+    file.write_all(&data.code_lens)?;
+
+    // Bitstream
+    file.write_all(&(data.bit_len as u64).to_le_bytes())?;
+    file.write_all(&(data.bitstream.len() as u32).to_le_bytes())?;
+    file.write_all(&data.bitstream)?;
+
+    Ok(())
+}
+
+/// Read a compressed WDL table from a file.
+pub fn read_wdl_file<P: AsRef<Path>>(path: P) -> io::Result<(MaterialKey, CompressedWdl)> {
+    let mut file = File::open(path)?;
+
+    // Header
+    let mut magic = [0u8; 4];
+    file.read_exact(&mut magic)?;
+    if &magic != MAGIC {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid magic"));
+    }
+
+    let mut version = [0u8; 1];
+    file.read_exact(&mut version)?;
+    if version[0] != VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unsupported version",
+        ));
+    }
+
+    // Material key
+    let mut mk_len = [0u8; 1];
+    file.read_exact(&mut mk_len)?;
+    let mk_len = mk_len[0] as usize;
+    let mut mk_bytes = vec![0u8; mk_len];
+    file.read_exact(&mut mk_bytes)?;
+    let mk_string = String::from_utf8(mk_bytes)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid material key"))?;
+    let material = MaterialKey::from_string(&mk_string)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid material key"))?;
+
+    // Table metadata
+    let mut buf8 = [0u8; 8];
+    file.read_exact(&mut buf8)?;
+    let orig_len = u64::from_le_bytes(buf8) as usize;
+
+    let mut buf2 = [0u8; 2];
+    file.read_exact(&mut buf2)?;
+    let base_symbols = u16::from_le_bytes(buf2);
+
+    // Symbol pairs
+    file.read_exact(&mut buf2)?;
+    let pair_len = u16::from_le_bytes(buf2) as usize;
+    let mut sym_pairs = Vec::with_capacity(pair_len);
+    for _ in 0..pair_len {
+        file.read_exact(&mut buf2)?;
+        let a = u16::from_le_bytes(buf2);
+        file.read_exact(&mut buf2)?;
+        let b = u16::from_le_bytes(buf2);
+        sym_pairs.push((a, b));
+    }
+
+    // Code lengths
+    file.read_exact(&mut buf2)?;
+    let lens_len = u16::from_le_bytes(buf2) as usize;
+    let mut code_lens = vec![0u8; lens_len];
+    file.read_exact(&mut code_lens)?;
+
+    // Bitstream
+    file.read_exact(&mut buf8)?;
+    let bit_len = u64::from_le_bytes(buf8) as usize;
+    let mut buf4 = [0u8; 4];
+    file.read_exact(&mut buf4)?;
+    let bs_len = u32::from_le_bytes(buf4) as usize;
+    let mut bitstream = vec![0u8; bs_len];
+    file.read_exact(&mut bitstream)?;
+
+    Ok((
+        material,
+        CompressedWdl {
+            base_symbols,
+            sym_pairs,
+            code_lens,
+            bitstream,
+            bit_len,
+            orig_len,
+        },
+    ))
+}

--- a/tests/wdl_file_roundtrip.rs
+++ b/tests/wdl_file_roundtrip.rs
@@ -1,0 +1,44 @@
+use heisenbase::{
+    compression::{compress_wdl, decompress_wdl},
+    material_key::MaterialKey,
+    wdl_file::{read_wdl_file, write_wdl_file},
+    wdl_score_range::WdlScoreRange,
+    wdl_table::WdlTable,
+};
+use shakmaty::Position;
+
+#[test]
+fn write_read_round_trip() {
+    let material = MaterialKey::from_string("KQvK").unwrap();
+    let total = material.total_positions();
+    let mut positions = Vec::with_capacity(total);
+    for idx in 0..total {
+        if let Some(position) = material.index_to_position(idx) {
+            let wdl = if position.is_checkmate() {
+                WdlScoreRange::Loss
+            } else if position.is_stalemate() || position.is_insufficient_material() {
+                WdlScoreRange::Draw
+            } else {
+                WdlScoreRange::Unknown
+            };
+            positions.push(wdl);
+        }
+    }
+
+    let table = WdlTable {
+        material,
+        positions,
+    };
+
+    let compressed = compress_wdl(&table.positions);
+
+    let path = std::env::temp_dir().join("kqvk_test.hbt");
+    write_wdl_file(&path, &table.material, &compressed).unwrap();
+
+    let (read_material, read_data) = read_wdl_file(&path).unwrap();
+    assert_eq!(read_material, table.material);
+    let decompressed = decompress_wdl(&read_data);
+    assert_eq!(decompressed, table.positions);
+
+    std::fs::remove_file(path).unwrap();
+}


### PR DESCRIPTION
## Summary
- add `generate` command logic to compress and write tables to `.hbt` files
- support serializing and reading compressed tables
- document the binary table format in `/documentation`

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688ec8a803e48320bb82ea152d06b278