### PR TITLE
Ignore integration test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ To contribute to this repository:
 
 - Run `cargo fmt -- --check` to ensure code is formatted.
 - Run `cargo test` and ensure all tests pass.
+- The integration test in `tests/wdl_file_roundtrip.rs` is ignored by default.
+  Run it explicitly with `cargo test -- --ignored`.
 - Keep pull request messages concise and mention the tests executed.
 
 These instructions apply to all files in this repository.

--- a/tests/wdl_file_roundtrip.rs
+++ b/tests/wdl_file_roundtrip.rs
@@ -8,6 +8,7 @@ use heisenbase::{
 use shakmaty::Position;
 
 #[test]
+#[ignore]
 fn write_read_round_trip() {
     let material = MaterialKey::from_string("KQvK").unwrap();
     let total = material.total_positions();


### PR DESCRIPTION
## Summary
- mark `wdl_file_roundtrip` integration test as ignored so it doesn't run with `cargo test`
- document how to run the ignored test in `AGENTS.md`

## Testing
- `cargo fmt -- --check`
- `cargo test`
- `cargo test -- --ignored`


------
https://chatgpt.com/codex/tasks/task_e_688ed771bd148320ba9c196cc555a141