### PR TITLE
Return Result from index_to_position

### DIFF
--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -40,10 +40,10 @@ impl TableBuilder {
         let mut updates = 0;
         for pos_index in 0..self.positions.len() {
             let old_score = self.positions[pos_index];
-            let position = self
-                .material
-                .index_to_position(pos_index)
-                .expect("every index should map to a position");
+            let position = match self.material.index_to_position(pos_index) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
 
             if old_score.is_certain() {
                 continue;

--- a/tests/kqvk_roundtrip.rs
+++ b/tests/kqvk_roundtrip.rs
@@ -12,16 +12,19 @@ fn compress_decompress_kqvk_table_round_trip() {
     let total = material.total_positions();
     let mut positions = Vec::with_capacity(total);
     for idx in 0..total {
-        if let Some(position) = material.index_to_position(idx) {
-            let wdl = if position.is_checkmate() {
-                WdlScoreRange::Loss
-            } else if position.is_stalemate() || position.is_insufficient_material() {
-                WdlScoreRange::Draw
-            } else {
-                WdlScoreRange::Unknown
-            };
-            positions.push(wdl);
-        }
+        let wdl = match material.index_to_position(idx) {
+            Ok(position) => {
+                if position.is_checkmate() {
+                    WdlScoreRange::Loss
+                } else if position.is_stalemate() || position.is_insufficient_material() {
+                    WdlScoreRange::Draw
+                } else {
+                    WdlScoreRange::Unknown
+                }
+            }
+            Err(_) => WdlScoreRange::Unknown,
+        };
+        positions.push(wdl);
     }
     let table = WdlTable {
         material,

--- a/tests/wdl_file_roundtrip.rs
+++ b/tests/wdl_file_roundtrip.rs
@@ -14,16 +14,19 @@ fn write_read_round_trip() {
     let total = material.total_positions();
     let mut positions = Vec::with_capacity(total);
     for idx in 0..total {
-        if let Some(position) = material.index_to_position(idx) {
-            let wdl = if position.is_checkmate() {
-                WdlScoreRange::Loss
-            } else if position.is_stalemate() || position.is_insufficient_material() {
-                WdlScoreRange::Draw
-            } else {
-                WdlScoreRange::Unknown
-            };
-            positions.push(wdl);
-        }
+        let wdl = match material.index_to_position(idx) {
+            Ok(position) => {
+                if position.is_checkmate() {
+                    WdlScoreRange::Loss
+                } else if position.is_stalemate() || position.is_insufficient_material() {
+                    WdlScoreRange::Draw
+                } else {
+                    WdlScoreRange::Unknown
+                }
+            }
+            Err(_) => WdlScoreRange::Unknown,
+        };
+        positions.push(wdl);
     }
 
     let table = WdlTable {


### PR DESCRIPTION
## Summary
- propagate shakmaty validation failures from `index_to_position`
- add `InvalidPosition` variant to `MaterialError`
- handle invalid positions in table builder and tests
- clarify how `index_to_position` maps indices that yield unreachable or illegal positions
- test that in-range indices for `KvK` can produce `InvalidPosition`
- derive `Clone`, `Copy`, `PartialEq`, and `Eq` for `MaterialError`

## Testing
- `cargo fmt -- --check`
- `cargo test`
- `cargo test -- --ignored`


------
https://chatgpt.com/codex/tasks/task_e_688f13f664408320922c8404d0e2c341