### PR TITLE
Add certainty helpers for WDL scores

### DIFF
--- a/src/wdl_score_range.rs
+++ b/src/wdl_score_range.rs
@@ -40,3 +40,15 @@ impl core::convert::TryFrom<u8> for WdlScoreRange {
         })
     }
 }
+
+impl WdlScoreRange {
+    /// Returns true if this score range represents a definite win, draw or loss.
+    pub fn is_certain(&self) -> bool {
+        matches!(self, Self::Win | Self::Draw | Self::Loss)
+    }
+
+    /// Returns true if this score range could represent multiple outcomes.
+    pub fn is_uncertain(&self) -> bool {
+        !self.is_certain()
+    }
+}

--- a/tests/wdl_score_range.rs
+++ b/tests/wdl_score_range.rs
@@ -1,0 +1,12 @@
+use heisenbase::wdl_score_range::WdlScoreRange;
+
+#[test]
+fn certainty_checks() {
+    assert!(WdlScoreRange::Win.is_certain());
+    assert!(WdlScoreRange::Draw.is_certain());
+    assert!(WdlScoreRange::Loss.is_certain());
+
+    assert!(WdlScoreRange::WinOrDraw.is_uncertain());
+    assert!(WdlScoreRange::DrawOrLoss.is_uncertain());
+    assert!(WdlScoreRange::Unknown.is_uncertain());
+}


### PR DESCRIPTION
## Summary
- add helpers to check certainty of WDL score ranges
- test certainty helpers

## Testing
- `cargo fmt -- --check`
- `cargo test`
- `cargo test -- --ignored`


------
https://chatgpt.com/codex/tasks/task_e_689559a0e804832087f530e2157aabc5